### PR TITLE
7-card-skeleton 기능 추가를 위한 PR

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -92,8 +92,17 @@ function CardContent({
   );
 }
 
+function CardSkeleton() {
+  return (
+    <div className={styles.card__wrapper}>
+      <div className="card__skeleton"></div>
+    </div>
+  );
+}
+
 const Card = Object.assign(CardContainer, {
   CardContent,
+  CardSkeleton,
 });
 
 export default Card;

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -95,7 +95,7 @@ function CardContent({
 function CardSkeleton() {
   return (
     <div className={styles.card__wrapper}>
-      <div className="card__skeleton"></div>
+      <div className={styles.card__skeleton}></div>
     </div>
   );
 }

--- a/src/components/card/Section.tsx
+++ b/src/components/card/Section.tsx
@@ -2,6 +2,8 @@
 
 import Card from "@/components/card/Card";
 import styles from "@/styles/components/card.module.scss";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 
 type RecruitData = {
   id: number;
@@ -18,9 +20,41 @@ type RecruitData = {
 };
 
 export default function CardSection({ data }: { data: RecruitData[] }) {
+  const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(false);
+  const [displayData, setDisplayData] = useState<RecruitData[]>(data);
+  
+  useEffect(() => {
+    // 회사 탭이 변경될 때 로딩 상태 활성화
+    const company = searchParams.get('company');
+    if (company) {
+      setIsLoading(true);
+      
+      // 데이터가 로드되면 로딩 상태 비활성화 (실제로는 서버 컴포넌트에서 데이터를 가져오므로 약간의 지연만 시뮬레이션)
+      const timer = setTimeout(() => {
+        setIsLoading(false);
+        setDisplayData(data);
+      }, 800);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [searchParams, data]);
+
+  if (isLoading) {
+    return (
+      <section className={styles.card__section}>
+        {[...Array(4)].map((_, index) => (
+          <Card key={`skeleton-${index}`}>
+            <Card.CardSkeleton />
+          </Card>
+        ))}
+      </section>
+    );
+  }
+
   return (
     <section className={styles.card__section}>
-      {data.map((item) => (
+      {displayData.map((item) => (
         <Card key={item.id}>
           <Card.CardContent
             title={item.annoSubject}


### PR DESCRIPTION
## 진행현황

**1. Card.tsx에 스켈레톤 UI를 위한 CardSkeleton 컴포넌트를 추가했습니다.**
- 기존 style.scss에 정의된 card__skeleton 클래스를 활용합니다.
- 코드 스타일은 기존 패턴을 유지했습니다.

**2. Section.tsx 파일을 수정하여 로딩 상태를 추가했습니다.**
- useState와 useEffect를 사용하여 로딩 상태를 관리합니다.
- useSearchParams를 통해 회사 탭이 변경될 때 로딩 상태를 활성화합니다.
- 로딩 중에는 CardSkeleton 컴포넌트를 표시합니다(4개의 스켈레톤 카드 생성).

## 버그
Skeleton의 width가 최소화된 상태로 표시되는 버그가 있습니다.

### 원인
**card__skeleton 클래스의 width: 100%가 적용되지 않고 있습니다.**
- card__skeleton의 width: 100%는 부모 요소의 너비에 상대적입니다.
- 부모 요소인 card__wrapper의 너비가 명시적으로 설정되어 있지 않고, 내용물에 의해 결정됩니다.
- 스켈레톤에는 내용물 없으므로 card__wrapper가 최소 너비로 줄어듭니다.
- 결과적으로 card__skeleton의 100% 너비도 작은 값이 됩니다.

> Card.CardContent는 실제 데이터로 채워져 있어 카드의 크기가 확장됩니다.

### 해결책

아래 두가지 중 하나로 정해야 합니다.

**1. 부모 요소인 card__wrapper 자체를 수정합니다.**
- 전체적인 레이아웃 구조에 직접 영향을 미칠 가능성이 있습니다.
- Card 내부에서 작업하는게 불가능합니다.

**2. 스켈레톤 카드 내부에 명시적으로 너비를 설정한 skeleton block을 넣습니다.**
- 크기를 명시적으로 설정하는 경우 반응형에 영향을 미칠 수 있습니다.
- 계산을 통한 방법도 있지만, 비효율적으로 보입니다.